### PR TITLE
Extend token and send-notification route

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dotenv": "^2.0.0",
     "express": "^4.14.0",
     "pug": "^2.0.0-beta6",
+    "camelcase": "^4.1.0",
     "twilio": "3.1.0-alpha-1"
   },
   "devDependencies": {

--- a/public/notify/notify.js
+++ b/public/notify/notify.js
@@ -1,7 +1,8 @@
 $(function() {
   $('#sendNotificationButton').on('click', function() {
     $.post('/send-notification', {
-      identity: $('#identityInput').val()
+      identity: $('#identityInput').val(),
+      body: "Hello, world!"
     }, function(response) {
       $('#identityInput').val('');
       $('#message').html(response.message);

--- a/src/notification_handler.js
+++ b/src/notification_handler.js
@@ -6,10 +6,6 @@ const config = require('./config');
  * Create a device binding from a POST HTTP request
  *
  * @param {Object} binding
- *        {Object.endpoint} String
- *        {Object.identity} String
- *        {Object.bindingType} String
- *        {Object.address} String
  *
  * @return {Promise}
  *         {Object.status}

--- a/src/notification_handler.js
+++ b/src/notification_handler.js
@@ -39,15 +39,12 @@ exports.registerBind = function registerBind(binding) {
 };
 
 // Notify - send a notification from a POST HTTP request
-exports.sendNotification = function sendNotification(identity) {
+exports.sendNotification = function sendNotification(notification) {
   // Create a reference to the user notification service
   const service = getTwilioClient();
 
   // Send a notification
-  return service.notifications.create({
-    'identity': identity,
-    'body': 'Hello, world!',
-  }).then((message) => {
+  return service.notifications.create(notification).then((message) => {
     console.log(message);
     return {
       status: 200,

--- a/src/router.js
+++ b/src/router.js
@@ -30,8 +30,7 @@ router.post('/register', (req, res) => {
 });
 
 router.post('/send-notification', (req, res) => {
-  const identity = req.body.identity;
-  sendNotification(identity).then((data) => {
+  sendNotification(req.body).then((data) => {
     res.status(data.status);
     res.send(data.data);
   });

--- a/src/router.js
+++ b/src/router.js
@@ -10,6 +10,11 @@ router.get('/token', (req, res) => {
   res.send(tokenGenerator());
 });
 
+router.post('/token', (req, res) => {
+  const identity = req.body.identity;
+  res.send(tokenGenerator(identity));
+});
+
 router.post('/register', (req, res) => {
   const endpoint = req.body.endpoint;
   const identity = req.body.identity;

--- a/src/router.js
+++ b/src/router.js
@@ -16,14 +16,7 @@ router.post('/token', (req, res) => {
 });
 
 router.post('/register', (req, res) => {
-  const endpoint = req.body.endpoint;
-  const identity = req.body.identity;
-  const bindingType = req.body.BindingType;
-  const address = req.body.Address;
-  registerBind({
-    endpoint, identity,
-    bindingType, address
-  }).then((data) => {
+  registerBind(req.body).then((data) => {
     res.status(data.status);
     res.send(data.data);
   });

--- a/src/router.js
+++ b/src/router.js
@@ -6,6 +6,17 @@ const config = require('./config');
 
 const router = new Router();
 
+// Convert keys to camelCase to conform with the twilio-node api definition contract
+const camelCase = require('camelcase');
+function camelCaseKeys(hashmap) {
+  var newhashmap = {};
+  Object.keys(hashmap).forEach(function(key) {
+    var newkey = camelCase(key);
+    newhashmap[newkey] = hashmap[key];
+  });
+  return newhashmap;
+};
+
 router.get('/token', (req, res) => {
   res.send(tokenGenerator());
 });
@@ -16,14 +27,16 @@ router.post('/token', (req, res) => {
 });
 
 router.post('/register', (req, res) => {
-  registerBind(req.body).then((data) => {
+  var content = camelCaseKeys(req.body);
+  registerBind(content).then((data) => {
     res.status(data.status);
     res.send(data.data);
   });
 });
 
 router.post('/send-notification', (req, res) => {
-  sendNotification(req.body).then((data) => {
+  var content = camelCaseKeys(req.body);
+  sendNotification(content).then((data) => {
     res.status(data.status);
     res.send(data.data);
   });

--- a/src/token_generator.js
+++ b/src/token_generator.js
@@ -26,12 +26,8 @@ function tokenGenerator(identity = 0) {
     config.TWILIO_API_SECRET
   );
 
-  if (identity) {
-    token.identity = identity;
-  } else {
-    // Assign the generated identity to the token
-    token.identity = nameGenerator();
-  }
+  // Assign the provided identity or generate a new one
+  token.identity = identity || nameGenerator();
 
   // Grant the access token Twilio Video capabilities
   const videoGrant = new VideoGrant();

--- a/src/token_generator.js
+++ b/src/token_generator.js
@@ -11,14 +11,14 @@ const SyncGrant = AccessToken.SyncGrant;
 
 /**
  * Generate an Access Token for an application user - it generates a random
- * username for the client requesting a token, and takes a device ID as a query
- * parameter.
+ * username for the client requesting a token or generates a token with an
+ * identity if one is provided.
  *
  * @return {Object}
  *         {Object.identity} String random indentity
  *         {Object.token} String token generated
  */
-function tokenGenerator() {
+function tokenGenerator(identity = 0) {
   // Create an access token which we will sign and return to the client
   const token = new AccessToken(
     config.TWILIO_ACCOUNT_SID,
@@ -26,8 +26,12 @@ function tokenGenerator() {
     config.TWILIO_API_SECRET
   );
 
-  // Assign the generated identity to the token
-  token.identity = nameGenerator();
+  if (identity) {
+    token.identity = identity;
+  } else {
+    // Assign the generated identity to the token
+    token.identity = nameGenerator();
+  }
 
   // Grant the access token Twilio Video capabilities
   const videoGrant = new VideoGrant();

--- a/test/token_generator.test.js
+++ b/test/token_generator.test.js
@@ -10,4 +10,15 @@ describe('#tokenGenerator', () => {
     expect(decoded).toHaveProperty('payload.grants.ip_messaging.service_sid');
     expect(decoded).toHaveProperty('payload.grants.data_sync.service_sid');
   });
+
+  it('generates a new token using the specified identity', () => {
+    const identity = "Alice";
+    const token = tokenGenerator(identity);
+    const decoded = jwt.decode(token.token, {complete: true});
+
+    expect(token.identity).toEqual(identity);
+    expect(decoded).toHaveProperty('payload.grants.identity', token.identity);
+  });
+
+
 });


### PR DESCRIPTION
- Allow the token route to generate a token based on an identity if one is provided
- Make the send-notification route generic to allow for sending any notification in addition to the previously hard-coded "hello world" notification
- Make registration more flexible to allow for creating any kind of binding

The motivation for these changes stems from wanting to obtain a token from a previously registered identity and send custom notifications from a mobile app.

The `camelCase` conversion is implemented to ensure that developers who write their model objects based on the keys defined in the REST API as `CamelCase`, or `camelCase` or `snake_case` all convert gracefully when using the `twilio-node` library which expects keys to be `camelCase`.