### PR TITLE
Change post to get

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -41,7 +41,7 @@ router.get('/token/:id', (req, res) => {
   });
 });
 
-router.post('/token', (req, res) => {
+router.get('/token', (req, res) => {
   const identity = req.body.identity;
   res.send(tokenGenerator(identity));
 });


### PR DESCRIPTION
Changed router's POST /token to GET /token to fix 404 error in Twilio Sync demo.

I installed and ran this demo app to tinker with Twilio Sync, but the Sync app 404's at the call to GET /token. The route is configured as `router.post('/token'` so I changed it to `router.get('/token'` and got Sync to work. Hope this helps and doesn't break anything else :)